### PR TITLE
Simplified compose - less redundant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM nginx:alpine
 COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,10 +3,8 @@ services:
     container_name: personal-website
     build:
       context: .
-      dockerfile: Dockerfile
     ports:
-      - "3888:80"
+      - 8080:80
     volumes:
-      - /usr/share/nginx/html
+      - .:/usr/share/nginx/html
     restart: always
-    command: nginx -g 'daemon off;'


### PR DESCRIPTION
I removed the command: nginx -g 'daemon off;' line from the compose.yaml file which was making it redundant because the official nginx:alpine image already runs with nginx -g 'daemon off;' as its default command. Removing it simplifies the compose file without changing functionality.